### PR TITLE
Fix GitHub streak and trophy image URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ I'm a DevOps and cloud engineer with a passion for building scalable systems and
   <img src="https://github-readme-stats.vercel.app/api?username=rajcommit&show_icons=true&theme=radical" alt="GitHub stats"/>
 </p>
 <p>
-  <img src="https://streak-stats.demolab.com?user=rajcommit&theme=radical" alt="GitHub streak"/>
+  <img src="https://streak-stats.demolab.com/?user=rajcommit&theme=radical" alt="GitHub streak"/>
 </p>
 <p>
   <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=rajcommit&layout=compact&theme=radical" alt="Top languages"/>
@@ -50,7 +50,7 @@ I'm a DevOps and cloud engineer with a passion for building scalable systems and
 
 ## 🏆 Achievements
 <p>
-  <img src="https://github-profile-trophy.vercel.app/?username=rajcommit&theme=radical&margin-w=15&margin-h=15" alt="GitHub trophies"/>
+  <img src="https://github-profile-trophy.vercel.app/?username=rajcommit&theme=radical" alt="GitHub trophies"/>
 </p>
 
 ## 🤝 Connect with Me


### PR DESCRIPTION
## Summary
- fix GitHub streak image link
- simplify GitHub trophy image URL

## Testing
- `pytest`
- `pre-commit run --files README.md` *(fails: command not found, attempted install but no matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_689adb4435548327bdce7758412d6f99