### PR TITLE
fix: correct hero banner link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ---
 <p align="center">
-  <img src="https://github.com/rajcommit/rajcommit/blob/main/assets/hero.gif" alt="Hero Banner" width="100%"/>
+  <img src="https://raw.githubusercontent.com/rajcommit/rajcommit/main/assets/hero.gif" alt="Hero Banner" width="100%"/>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- fix hero banner image URL to use raw GitHub path for reliability

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b3a4428b48327a0a6460d26d39954