### PR TITLE
Replace GitHub streak stats with activity graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ I'm a DevOps and cloud engineer with a passion for building scalable systems and
   <img src="https://github-readme-stats.vercel.app/api?username=rajcommit&show_icons=true&theme=radical" alt="GitHub stats"/>
 </p>
 <p>
-  <img src="https://streak-stats.demolab.com/?user=rajcommit&theme=radical" alt="GitHub streak"/>
+  <img src="https://github-readme-activity-graph.vercel.app/graph?username=rajcommit&theme=radical" alt="GitHub activity graph"/>
 </p>
 <p>
   <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=rajcommit&layout=compact&theme=radical" alt="Top languages"/>


### PR DESCRIPTION
## Summary
- replace broken GitHub streak card with activity graph

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b3bfbfe24832795b112e4e23c6d41